### PR TITLE
Update loom to 1.7

### DIFF
--- a/bundle/fabric/build.gradle
+++ b/bundle/fabric/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 
 plugins {
-	id 'fabric-loom' version '1.6-SNAPSHOT'
+	id 'fabric-loom' version '1.7-SNAPSHOT'
 	id 'maven-publish'
 	id 'org.cadixdev.licenser' version '0.6.1'
 	id 'org.ajoberstar.grgit' version '4.1.1'


### PR DESCRIPTION
loom 1.7 lets you genSources without crashing
should I have updated to 1.8?

see @rhysdh540 it's not that hard